### PR TITLE
add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a problem or unexpected behavior
+title: "[BUG]"
+labels: bug
+assignees: ''
+---
+
+# Bug Report
+
+## Description
+A clear and concise description of the problem.
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS:
+- Python version:
+- Dependencies / versions:
+- bddbench version:
+
+## Additional Context
+Add any other context about the problem here, including logs, error messages, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+---
+
+# Feature Request
+
+## Description
+A clear and concise description of what you want to happen.
+
+## Motivation / Use Case
+Why is this feature needed? Describe the use case or problem it solves.
+
+## Proposed Solution
+Describe a possible solution or implementation approach, if known.
+
+## Additional Context
+Add any other context, screenshots, or references that may help.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+# Pull Request
+
+## Description
+Please include a summary of the changes and the context of the PR.  
+Include relevant motivation and links to issues this PR addresses.
+
+Fixes # (issue number)
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Improvement / refactoring
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+## How Has This Been Tested?
+Please describe the tests you ran to verify your changes. Include steps to reproduce if applicable:
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] Manual testing
+- [ ] Other (please describe):
+
+**Test Configuration**:
+- OS: 
+- Python version: 
+- Dependencies: 
+
+## Checklist:
+- [ ] My code follows the project’s style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code where necessary
+- [ ] I have added/updated tests as needed
+- [ ] I have updated the documentation if needed
+
+## Additional Notes
+Add any other context or screenshots about the PR here.


### PR DESCRIPTION
Issue and pull request workflow improvements:

* Added a bug report issue template to `.github/ISSUE_TEMPLATE/bug_report.md`, prompting users for detailed information about problems, reproduction steps, environment, and context.
* Added a feature request issue template to `.github/ISSUE_TEMPLATE/feature_request.md`, guiding users to describe desired features, motivations, and proposed solutions.
* Added a pull request template to `.github/PULL_REQUEST_TEMPLATE.md`, providing sections for change descriptions, testing, type of change, and checklists for contributors.