### PR TITLE
fix nixos deployment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
     pkgs.zlib
   ];
   in {
+   formatter.${system} = pkgs.nixfmt-tree;
+
     devShells.${system}.default = pkgs.mkShell {
       name = "env-with-secrets";
       buildInputs = [ pkgs.sops pkgs.yq pkgs.uv pkgs.python314FreeThreading pkgs.pkg-config pkgs.systemd.dev pkgs.gcc pkgs.stdenv.cc.cc.lib pkgs.zlib];
@@ -25,7 +27,6 @@
       NIX_LD_LIBRARY_PATH = libPath;
       LD_LIBRARY_PATH = libPath;
     };
-
 
 
 


### PR DESCRIPTION
# Pull Request

## Description
this pr fixes the bug that the env variables are not set and that the .so for numpy f.e. are not found when running on nixos.

Fixes # (issue number)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement / refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
Please describe the tests you ran to verify your changes. Include steps to reproduce if applicable:
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

**Test Configuration**:
- OS: ubuntu/nixos 
- Python version: 
- Dependencies: 

## Additional Notes
```
export ENV_NAME=johann && nix develop
warning: Git tree '/home/johann/bddbench' is dirty
🔐 Loading secrets from /nix/store/8xghx03spjskdyxbzdp5m46kdag2f5p5-source/secrets
Resolved 33 packages in 2ms
Audited 32 packages in 1ms
📄 Loading user env: ./envs/johann.env
🔑 Merging secrets from main_influx.enc.yaml
🔑 Merging secrets from sut_influx.enc.yaml
📤 Exporting merged .env
📄 Re-applying user env overrides into shell: ./envs/johann.env
🐍 Activating virtual environment...
✅ .venv found.
✅ .venv activated.
done.
```

```
behave
USING RUNNER: behave.runner:Runner
ABORTED: HOOK-ERROR in before_all: SystemExit

ABORTED: By user.
3 features passed, 0 failed, 0 skipped
0 scenarios passed, 0 failed, 0 skipped, 6 untested
0 steps passed, 0 failed, 0 skipped, 24 untested
Took 0min 0.000s
```